### PR TITLE
CAST-566

### DIFF
--- a/modules/authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLAuthorizationService.java
+++ b/modules/authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLAuthorizationService.java
@@ -165,6 +165,10 @@ public class XACMLAuthorizationService implements AuthorizationService {
                         new Match<AccessControlList, Option<AccessControlList>>() {
                           @Override
                           public Option<AccessControlList> some(AccessControlList a) {
+                            // TODO Why return none here?!
+                            //   Shouldn't this be `some(a)`?
+                            //   Also see my mailing list question for further comments on this method:
+                            //   https://groups.google.com/a/opencast.org/forum/#!topic/dev/CqGR1K3LNXE
                             return Option.<AccessControlList> none();
                           }
 

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
@@ -767,6 +767,12 @@ public class IndexServiceImpl implements IndexService {
     if (allEventMetadataJson == null)
       throw new IllegalArgumentException("No metadata field in metadata");
 
+    // TODO This returns an empty access control list when none is given in the `metadataJson`.
+    //   Is this sensible? This way, we can never create an event (using this code path)
+    //   that does **not** have an episode ACL.
+    //   An alternative solution to the CAST-566 problem would be to make this optional,
+    //   thus not creating the scheduler message to update the ACL,
+    //   avoiding the race condition alltogether.
     AccessControlList acl = getAccessControlList(metadataJson);
 
     MetadataList metadataList = getMetadataListWithAllEventCatalogUIAdapters();

--- a/modules/scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
+++ b/modules/scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
@@ -297,6 +297,10 @@ public class SchedulerServiceImplTest {
     EasyMock.expect(
             authorizationService.getAcl(EasyMock.anyObject(MediaPackage.class), EasyMock.anyObject(AclScope.class)))
             .andReturn(Option.some(acl)).anyTimes();
+    EasyMock.expect(
+            authorizationService.getActiveAcl(EasyMock.anyObject(MediaPackage.class)))
+            .andReturn(tuple(acl, AclScope.Episode)).anyTimes();
+
 
     orgDirectoryService = EasyMock.createNiceMock(OrganizationDirectoryService.class);
     EasyMock.expect(orgDirectoryService.getOrganizations())


### PR DESCRIPTION
This PR contains my current work towards the resolution of CAST-566.
The patch works in that it fixes the problem described in that issue.
It is not even SWITCH-specific and it should not break anything
in the community version, but admittedly I have not thought through
all the edge cases that all the different ways to get a hold of an ACL
for a media package present.

What the patch does is just get rid of all the calls to `XACMLAuthorizationManager#getAcl`,
which is the strange function I asked about on [the list](https://groups.google.com/a/opencast.org/forum/#!topic/dev/CqGR1K3LNXE),
and which @lkiesow and I briefly discussed, and replace them with `getActiveAcl`.

I also left in some `TODO` notes that I made for myself during debugging.
These mainly point to other potential approaches to the problem
and strange/bad/... code that I found in its vicinity.
These would of course have to be taken out (or the issues fixed in some way)
if this were to be made into a real PR, but I put them all in a separate commit,
to make that easier.

For reference and potential further investigation should my patch prove insufficient,
here is a relatively detailed description of the problem as I came to understand it:

## Problem description

So what happens, roughly, is this:

When hitting the submit button on the "new event" wizard,
a corresponding request arrives at `AbstractEventEndpoint#createNewEvent`,
which basically only delegates to `IndexServiceImpl#createEvent(HttpServletRequest)`.
Interesting to note here is that in the SWITCH case,
the request does not contain any information about ACLs.

The aforementioned `IndexServiceImpl#createEvent(HttpServletRequest)` pushes some data around
and delegates further to `IndexServiceImpl#createEvent(JSONObject, MediaPackage)`.
In here, we try to extract an ACL from the `JSONObject`,
which contains the submitted metadata from the request mentioned above,
using `IndexServiceImpl#getAccessControlList`.
In the SWITCH case, there is nothing to find there;
however, in that case, `getAccessControlList` just returns a new, empty ACL.

After some further data massaging, we land in another `createEvent` overload,
namely `IndexServiceImpl#createEvent(EventHttpServletRequest)`.
This method finally does some real work. Among other things,
it constructs a `MediaPackage` and adds the series and episode ACLs to it.
In the SWITCH case, the episode ACL is just an empty list,
because nothing was in the request and then the step above constructed ann empty one.
And then the method does the actual scheduling via `SchedulerServiceImpl#addEvent`,
which gets that media package as a parameter.

`addEvent` ist just a wrapper around `addEventInternal` for some reason,
but having arrived here, we are finally done with the setup
and can start to look at the actual problem:
`addEventInternal` first calls `persistEvent`,
which in turn instructs the asset manager to take a snapshot.
The message to start this asynchronous process is created
in `AssetManagerWithMessaging#mkTakeSnapshotMessage`,
and it uses `XACMLAuthorizationService#getActiveAcl`
to get the ACL to pass along with that message,
which (one of?) the handler(s?) for that message,
namely `AssetManagerMessageReceiverImpl` then (again, asynchronously)
puts in the `AdminUISearchIndex`, which is used to query
whether or not a user is allowed to see an event.
So far, so good. In the SWITCH case, that call merges the episode
and series ACL and all is well.

After that asynchronous message, it calls `sendUpdateAddEvent`,
passing it all the metadata about the new event.
This method then generates scheduler messages to update all the metadata,
which will again be handled asynchronously.
The ACL used for **this** call however is determined
using `XACMLAuthorizatioSerivce#getAcl(MediaPackage, AclScope)`,
passing `Episode` for the `AclScope` argument.
In our case, this will be the empty ACL from the beginning again,
so here the scheduler creates a message to update the ACL
of the given media package to an empty one.
This is handled by `SchedulerMessageReceiverImpl`,
again updating the `AdminUISearchIndex` accordingly.

Now we have a classic race condition.
In most of my tests, the asset manager handler was called first,
writing the correct ACLs to the admin UI index,
only to then be overwritten by the empty ACL from the scheduler messages.
However, I have witnessed the reverse case two or three times,
in which case the bug described in CAST-566 does not occur.

## What does not work, even with the provided fix?

I only just noticed this and have not looked into it any further:
When you rebuild the index, the unchanged events disappear again.